### PR TITLE
MySQL用のマイグレーションツールを利用出来るように設定を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN set -eux && \
   go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger && \
   go get -u github.com/oxequa/realize && \
   go get -u github.com/go-delve/delve/cmd/dlv && \
-  go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv
+  go build -o /go/bin/dlv github.com/go-delve/delve/cmd/dlv && \
+  go get -tags 'mysql' -u github.com/golang-migrate/migrate/cmd/migrate
 
 WORKDIR /go


### PR DESCRIPTION
# 課題URL（JIRAかGitHub issue）
https://github.com/nurse-senka/golang-docker/issues/5

# PRのDoneの定義
- MySQLのマイグレーションが実行出来るツールが利用出来るようになっている事

# 変更点概要
- `golang-migrate/migrate` を追加